### PR TITLE
chore: update branch naming and clarify installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, develop]
   pull_request:
-    branches: [main, dev]
+    branches: [main, develop]
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ graph TD
 
 ### Installation
 
+> **Note:** PyPI publishing is in progress (see [#10](https://github.com/Sosoka-Labs/truthfulness-evaluator/issues/10)).
+> For now, install from source:
+>
+> ```bash
+> pip install git+https://github.com/Sosoka-Labs/truthfulness-evaluator.git
+> ```
+
+Once published:
 ```bash
 pip install truthfulness-evaluator
 ```


### PR DESCRIPTION
This PR includes two commits:

1. **ci: rename dev branch to develop** — Updates CI workflow triggers to use  instead of  for sosoka-labs org consistency

2. **docs: clarify installation** — Adds a note that PyPI publishing is in progress (#10) and provides source install instructions

Both changes are prerequisites for proper PyPI publishing workflow setup.

Closes: README confusion about pip install
Related: #10