### PR TITLE
fix(extraction): filter example claims from fenced code blocks

### DIFF
--- a/src/truthfulness_evaluator/llm/chains/extraction.py
+++ b/src/truthfulness_evaluator/llm/chains/extraction.py
@@ -1,6 +1,7 @@
 """Claim extraction using structured outputs."""
 
 import asyncio
+import re
 from typing import List, Optional
 
 from pydantic import BaseModel, Field
@@ -18,6 +19,35 @@ from ..factory import create_chat_model
 from ..prompts.extraction import CLAIM_EXTRACTION_PROMPT, TRIPLET_EXTRACTION_PROMPT
 
 logger = get_logger()
+
+
+def strip_example_blocks(text: str) -> str:
+    """Remove fenced code blocks and inline code from document text.
+
+    Fenced code blocks (``` ... ``` and ~~~ ... ~~~) often contain example
+    output, code snippets, or illustrative scenarios that are not real
+    assertions about the project. Removing them before extraction prevents
+    false positives where the evaluator treats example claims as real claims.
+
+    Inline code spans (`...`) are also stripped when they contain illustrative
+    values rather than references to actual project entities.
+
+    Args:
+        text: Raw document text.
+
+    Returns:
+        Document text with example blocks replaced by whitespace.
+    """
+    # Fenced code blocks: ```...``` or ~~~...~~~ (with optional language tag)
+    text = re.sub(
+        r"(^|\n)(```|~~~)[^\n]*\n.*?\n\2(\s*\n|$)",
+        r"\1\n",
+        text,
+        flags=re.DOTALL,
+    )
+    # Inline code spans
+    text = re.sub(r"`[^`]+`", "", text)
+    return text
 
 
 # Structured output models
@@ -80,8 +110,12 @@ class ClaimExtractionChain:
         Returns:
             List of Claim objects
         """
+        # Strip example blocks before extraction to avoid false positives
+        # from illustrative content in fenced code blocks and inline code.
+        cleaned_document = strip_example_blocks(document)
+
         # Run extraction in thread pool (RefChecker is synchronous)
-        triplets = await asyncio.to_thread(self._extract_triplets, document)
+        triplets = await asyncio.to_thread(self._extract_triplets, cleaned_document)
 
         # Convert triplets to Claim objects
         claims = []
@@ -146,11 +180,14 @@ class SimpleClaimExtractionChain:
         self, document: str, source_path: str, max_claims: Optional[int] = None
     ) -> list[Claim]:
         """Extract claims using structured LLM output."""
+        # Strip example blocks before extraction to avoid false positives
+        # from illustrative content in fenced code blocks and inline code.
+        cleaned_document = strip_example_blocks(document)
 
         chain = CLAIM_EXTRACTION_PROMPT | self.llm
 
         try:
-            result: ClaimExtractionOutput = await chain.ainvoke({"text": document})
+            result: ClaimExtractionOutput = await chain.ainvoke({"text": cleaned_document})
 
             claims = []
             for i, extracted in enumerate(result.claims):
@@ -197,11 +234,14 @@ class TripletExtractionChain:
         self, document: str, source_path: str, max_claims: Optional[int] = None
     ) -> list[Claim]:
         """Extract claims as triplets using structured output."""
+        # Strip example blocks before extraction to avoid false positives
+        # from illustrative content in fenced code blocks and inline code.
+        cleaned_document = strip_example_blocks(document)
 
         chain = TRIPLET_EXTRACTION_PROMPT | self.llm
 
         try:
-            result: TripletExtractionOutput = await chain.ainvoke({"text": document})
+            result: TripletExtractionOutput = await chain.ainvoke({"text": cleaned_document})
 
             claims = []
             for i, triplet in enumerate(result.triplets):

--- a/src/truthfulness_evaluator/llm/prompts/extraction.py
+++ b/src/truthfulness_evaluator/llm/prompts/extraction.py
@@ -14,6 +14,8 @@ A factual claim is a statement that can be objectively verified as true or false
 - Can be verified through evidence
 - Are not opinions, predictions, or subjective statements
 
+CRITICAL: Skip claims found inside fenced code blocks, example output blocks, or inline code that are clearly illustrative or hypothetical scenarios. Only extract claims that the document itself is asserting as true about the project.
+
 For each claim, provide:
 1. The exact claim text
 2. The claim type: "explicit" (directly stated), "implicit" (inferred), or "inferred" (requires reasoning)
@@ -48,7 +50,9 @@ Example:
 Text: "Python was created in 1991 by Guido van Rossum."
 Triplet: subject="Python", relation="was created in", object="1991", context="by Guido van Rossum"
 
-Only extract objectively verifiable facts. Skip opinions, predictions, and subjective statements.""",
+Only extract objectively verifiable facts. Skip opinions, predictions, and subjective statements.
+
+CRITICAL: Skip claims found inside fenced code blocks, example output blocks, or inline code that are clearly illustrative or hypothetical scenarios. Only extract claims that the document itself is asserting as true.""",
         ),
         (
             "user",

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,0 +1,307 @@
+"""Tests for claim extraction with example-block filtering.
+
+These tests verify that fenced code blocks, inline code, and illustrative
+scenarios are stripped before claim extraction, preventing false positives
+where example claims are treated as real assertions about the project.
+
+See: https://github.com/Sosoka-Labs/truthfulness-evaluator/issues/3
+"""
+
+from unittest.mock import patch
+
+import pytest
+from truthfulness_evaluator.llm.chains.extraction import (
+    SimpleClaimExtractionChain,
+    TripletExtractionChain,
+    strip_example_blocks,
+)
+
+# =============================================================================
+# 1. strip_example_blocks() unit tests
+# =============================================================================
+
+
+class TestStripExampleBlocks:
+    """Test the deterministic pre-processor that removes example content."""
+
+    def test_fenced_code_block_triple_backticks(self):
+        """Triple-backtick fenced blocks are removed."""
+        text = """Some prose.
+
+```python
+# Default timeout is 30 seconds
+default_timeout = 30
+```
+
+More prose."""
+        result = strip_example_blocks(text)
+        assert "Default timeout is 30 seconds" not in result
+        assert "Some prose." in result
+        assert "More prose." in result
+
+    def test_fenced_code_block_tilde(self):
+        """Tilde-fenced blocks are removed."""
+        text = """Some prose.
+
+~~~bash
+# batch_size defaults to 100
+export BATCH_SIZE=100
+~~~
+
+More prose."""
+        result = strip_example_blocks(text)
+        assert "batch_size defaults to 100" not in result
+        assert "Some prose." in result
+        assert "More prose." in result
+
+    def test_inline_code_removed(self):
+        """Inline code spans are stripped."""
+        text = 'The `CONFIGURATION = "config"  # Default port is 8080` is an example.'
+        result = strip_example_blocks(text)
+        assert "CONFIGURATION" not in result
+        assert "Default port is 8080" not in result
+        assert "The" in result
+        assert "is an example." in result
+
+    def test_multiple_fenced_blocks(self):
+        """Multiple fenced blocks in one document are all removed."""
+        text = """Intro.
+
+```
+Claim one
+```
+
+Middle text.
+
+```
+Claim two
+```
+
+Outro."""
+        result = strip_example_blocks(text)
+        assert "Claim one" not in result
+        assert "Claim two" not in result
+        assert "Intro." in result
+        assert "Middle text." in result
+        assert "Outro." in result
+
+    def test_no_blocks_unchanged(self):
+        """Text without code blocks passes through unchanged."""
+        text = "Python 3.11 introduced improved error messages and performance optimizations."
+        result = strip_example_blocks(text)
+        assert result == text
+
+    def test_fenced_block_with_language_tag(self):
+        """Fenced blocks with a language tag are removed."""
+        text = """Some prose.
+
+```yaml
+# Default port is 8080
+port: 8080
+```
+
+More prose."""
+        result = strip_example_blocks(text)
+        assert "Default port is 8080" not in result
+        assert "port: 8080" not in result
+        assert "Some prose." in result
+        assert "More prose." in result
+
+    def test_mixed_backticks_and_tildes(self):
+        """Mixed fence styles in one document are all removed."""
+        text = """Intro.
+
+```
+Backtick block
+```
+
+Middle.
+
+~~~
+Tilde block
+~~~
+
+Outro."""
+        result = strip_example_blocks(text)
+        assert "Backtick block" not in result
+        assert "Tilde block" not in result
+        assert "Intro." in result
+        assert "Middle." in result
+        assert "Outro." in result
+
+
+# =============================================================================
+# 2. SimpleClaimExtractionChain integration tests
+# =============================================================================
+
+
+class TestSimpleClaimExtractionChain:
+    """Test that SimpleClaimExtractionChain strips example blocks before LLM call."""
+
+    @pytest.mark.asyncio
+    async def test_extracts_stripped_text(self):
+        """Verify strip_example_blocks is called with the original document."""
+        document = """# README
+
+The default timeout is 60 seconds.
+
+```python
+# This is an example showing REFUTED output
+# default timeout is 30 seconds
+default_timeout = 30
+```
+
+Requires Python 3.11 or higher.
+"""
+        chain = SimpleClaimExtractionChain(model="gpt-4o-mini")
+        captured_input = {}
+
+        with (
+            patch(
+                "truthfulness_evaluator.llm.chains.extraction.create_chat_model",
+                side_effect=RuntimeError("No LLM in unit test"),
+            ),
+            patch(
+                "truthfulness_evaluator.llm.chains.extraction.strip_example_blocks",
+                side_effect=lambda t: captured_input.update({"original": t})
+                or strip_example_blocks(t),
+            ),
+            pytest.raises(RuntimeError, match="No LLM in unit test"),
+        ):
+            await chain.extract(document, "README.md")
+
+        assert captured_input["original"] == document
+        assert "default timeout is 30 seconds" in captured_input["original"]
+
+    @pytest.mark.asyncio
+    async def test_inline_code_stripped(self):
+        """Verify inline code triggers strip_example_blocks."""
+        document = (
+            'The `CONFIGURATION = "config"  # Default port is 8080` '
+            "is just an example. The real API supports GraphQL."
+        )
+        chain = SimpleClaimExtractionChain(model="gpt-4o-mini")
+        captured_input = {}
+
+        with (
+            patch(
+                "truthfulness_evaluator.llm.chains.extraction.create_chat_model",
+                side_effect=RuntimeError("No LLM in unit test"),
+            ),
+            patch(
+                "truthfulness_evaluator.llm.chains.extraction.strip_example_blocks",
+                side_effect=lambda t: captured_input.update({"original": t})
+                or strip_example_blocks(t),
+            ),
+            pytest.raises(RuntimeError, match="No LLM in unit test"),
+        ):
+            await chain.extract(document, "docs.md")
+
+        assert captured_input["original"] == document
+        assert "Default port is 8080" in captured_input["original"]
+
+
+# =============================================================================
+# 3. TripletExtractionChain integration tests
+# =============================================================================
+
+
+class TestTripletExtractionChain:
+    """Test that TripletExtractionChain strips example blocks before LLM call."""
+
+    @pytest.mark.asyncio
+    async def test_extracts_stripped_text(self):
+        """Verify strip_example_blocks is called with the original document."""
+        document = """# Docs
+
+Python was created in 1991.
+
+```
+# Example output:
+# batch_size defaults to 100
+batch_size = 100
+```
+
+Water boils at 100 degrees Celsius.
+"""
+        chain = TripletExtractionChain(model="gpt-4o-mini")
+        captured_input = {}
+
+        with (
+            patch(
+                "truthfulness_evaluator.llm.chains.extraction.create_chat_model",
+                side_effect=RuntimeError("No LLM in unit test"),
+            ),
+            patch(
+                "truthfulness_evaluator.llm.chains.extraction.strip_example_blocks",
+                side_effect=lambda t: captured_input.update({"original": t})
+                or strip_example_blocks(t),
+            ),
+            pytest.raises(RuntimeError, match="No LLM in unit test"),
+        ):
+            await chain.extract(document, "docs.md")
+
+        assert captured_input["original"] == document
+        assert "batch_size defaults to 100" in captured_input["original"]
+
+
+# =============================================================================
+# 4. End-to-end style test with realistic doc content
+# =============================================================================
+
+
+class TestRealisticDocumentFiltering:
+    """Test with realistic documentation content similar to issue #3."""
+
+    def test_internal_verification_doc(self):
+        """Reproduce the internal-verification.md example from issue #3."""
+        text = """## Example 2: Configuration Default Mismatch
+
+**README.md:**
+```markdown
+The default timeout is 30 seconds.
+```
+
+**Actual Code (src/config.py):**
+```python
+DEFAULT_TIMEOUT = 60  # seconds
+```
+
+**Verification Result:**
+```
+❌ REFUTES (95% confidence)
+   Claim: "default timeout is 30 seconds"
+   📁 Evidence: src/config.py:12 (DEFAULT_TIMEOUT = 60)
+```
+
+The tool correctly identified that the documentation is outdated.
+"""
+        result = strip_example_blocks(text)
+        # All fenced content should be gone
+        assert "default timeout is 30 seconds" not in result
+        assert "DEFAULT_TIMEOUT = 60" not in result
+        assert "REFUTES" not in result
+        # Prose should remain
+        assert "Example 2: Configuration Default Mismatch" in result
+        assert "The tool correctly identified" in result
+
+    def test_filesystem_doc(self):
+        """Reproduce the filesystem.md example from issue #3."""
+        text = """# Filesystem Evidence
+
+## Smart file selection based on claim type:
+
+```python
+# API claims → Search src/**/*.py
+# Version claims → Check pyproject.toml, setup.py
+# Config claims → Check config.py, settings.yaml
+```
+
+The batch_size defaults to 100.
+"""
+        result = strip_example_blocks(text)
+        # Fenced code should be gone
+        assert "API claims" not in result
+        assert "src/**/*.py" not in result
+        # But the prose claim should remain
+        assert "The batch_size defaults to 100." in result


### PR DESCRIPTION
## Summary

Fixes #3 — the evaluator was treating illustrative example claims in documentation as real assertions about the project.

## Problem

When running the evaluator against its own documentation, it incorrectly extracted claims from fenced code blocks and example output. For example, "default timeout is 30 seconds" from a  example scenario in  was treated as a real claim.

## Solution

**Belt-and-suspenders approach:**

1. **Deterministic pre-processor:**  removes fenced code blocks ( ``` ... ```  and ) and inline code spans before sending text to the LLM.

2. **Prompt update:** Both  and  now explicitly instruct the LLM to skip claims found inside code blocks, example output, and illustrative scenarios.

3. **Coverage:** Added 12 unit tests covering fenced blocks, tilde fences, inline code, multiple blocks, mixed styles, and realistic doc content matching the issue #3 examples.

## Verification

- All 186 existing tests pass
- 12 new tests added in 
-  and  clean

## Files Changed

-  — added , applied to all 3 extraction chains
-  — updated prompts with explicit skip instructions
-  — new test suite