### PR TITLE
fix(ci): tighten AI review permissions, remove issue_comment trigger

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -7,15 +7,13 @@ name: AI Code Review
 on:
   pull_request:
     types: [opened, synchronize]
-  issue_comment:
 
 permissions:
-  contents: write
-  issues: write
+  contents: read
   pull-requests: write
 
 jobs:
-  ai-review:
+  review:
     uses: Sosoka-Labs/.github/.github/workflows/ai-code-review.yml@main
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Summary

Removes unnecessary permissions and the `issue_comment` trigger from the AI code review workflow.

### Changes
- Removed `issue_comment` trigger (not needed for auto-review on PR open/synchronize)
- Removed `contents: write` and `issues: write` permissions
- Kept minimal `contents: read` + `pull-requests: write`
- No functional change to review behavior