### PR TITLE
chore: sync main into develop (AI review permission fix)

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -7,15 +7,13 @@ name: AI Code Review
 on:
   pull_request:
     types: [opened, synchronize]
-  issue_comment:
 
 permissions:
-  contents: write
-  issues: write
+  contents: read
   pull-requests: write
 
 jobs:
-  ai-review:
+  review:
     uses: Sosoka-Labs/.github/.github/workflows/ai-code-review.yml@main
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Summary

The AI code review fix (tightened permissions, removed `issue_comment` trigger) was merged into `main` but `develop` still has the old workflow with excess permissions. This PR syncs `main` into `develop`.

### Changes
- Removes `issue_comment` trigger
- Removes `contents: write` and `issues: write` permissions
- Keeps minimal `contents: read` + `pull-requests: write`
- No functional code changes
