### PR TITLE
docs: standardize on develop branch, add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,85 @@
+# AGENTS.md
+
+Compact repo guide for OpenCode. High-signal facts only — if an agent would not guess it, it stays.
+
+## Project Overview
+
+Truthfulness Evaluator — Python CLI and library for multi-model claim verification with filesystem-aware evidence gathering. Uses LangGraph, LangChain, Pydantic v2. Target: Python 3.11+.
+
+## Package Layout
+
+- `src/truthfulness_evaluator/` — main package
+  - `truth.py` — CLI entry point (`truth-eval` command)
+  - `core/` — protocols, config, logging, grading
+  - `models/` — Pydantic domain models (Claim, TruthfulnessReport, etc.)
+  - `llm/` — LangGraph workflows, graph constructors, LLM factory
+  - `strategies/` — pluggable adapters: extractors, gatherers, verifiers, formatters
+  - `evidence/` — evidence gathering utilities
+  - `reporting/` — report generation
+- `tests/` — pytest suite (no `unit/` or `integration/` subdirs; tests are flat in `tests/`)
+- `docs/` — MkDocs documentation source
+
+## Environment & Setup
+
+- **Package manager:** Poetry. Always use `poetry install`, not `pip install -e .`.
+- **Install docs dependencies:** `poetry install --with docs`
+- **Required env vars:** `OPENAI_API_KEY` (required to run anything real). `ANTHROPIC_API_KEY` optional for multi-model consensus.
+- **Config prefix:** `TRUTH_` (e.g., `TRUTH_EXTRACTION_MODEL`, `TRUTH_CONFIDENCE_THRESHOLD`).
+- **Copy `.env.example` to `.env`** for local development.
+
+## Development Commands
+
+- **Run tests:** `poetry run pytest -m "not e2e" --tb=short`
+- **Run single test:** `poetry run pytest tests/test_something.py::test_name -v`
+- **Format:** `poetry run black src/ tests/`
+- **Lint:** `poetry run ruff check src/ tests/`
+- **Type check:** `poetry run mypy src/`
+- **Docs dev server:** `poetry run mkdocs serve` (or `mkdocs serve` if mkdocs is available globally)
+- **Build docs:** `poetry run mkdocs build --strict`
+
+## Toolchain Config
+
+| Tool | Config location | Key facts |
+|------|-----------------|-----------|
+| Black | `pyproject.toml` [tool.black] | line-length = 100, target py311 |
+| Ruff | `pyproject.toml` [tool.ruff] | line-length = 100, rules: E,F,I,N,W,UP,B,C4,SIM; ignores E501,B008 |
+| mypy | `pyproject.toml` [tool.mypy] | strict = true, python_version = 3.11 |
+| pytest | `pyproject.toml` [tool.pytest.ini_options] | asyncio_mode = auto, testpaths = ["tests"], markers: e2e, slow |
+
+## CI / Git Workflow
+
+- **CI triggers:** pushes and PRs to `main` and `develop`.
+- **CI job order:** lint (Ruff) → format check (Black) → tests (pytest excluding e2e).
+- **Branch model:** `main` = stable releases; `develop` = active development. Feature branches branch from `develop` and PRs target `develop`. Releases are merged from `develop` → `main` via PR.
+- **Merging workflow:** New work → feature branch → PR to `develop` → PR `develop` → `main` for release.
+- **Conventional commits:** `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`.
+- **AI code review:** All PRs trigger `Sosoka-Labs/.github/.github/workflows/ai-code-review.yml@main` via `OPENAI_API_KEY` secret.
+- **Docs deploy:** `mkdocs build --strict` → GitHub Pages on every push to `main` that touches `docs/**`, `mkdocs.yml`, or `src/**`.
+
+## Testing Notes
+
+- **E2E tests** are marked `@pytest.mark.e2e` and require real API keys. CI excludes them with `-m "not e2e"`. Do not run E2E tests in CI or without valid keys.
+- **Slow tests** are marked `@pytest.mark.slow` ( > 5 seconds).
+- **Mock external API calls** in unit tests.
+- **pytest-asyncio** is in auto mode; `async` tests do not need explicit decorators.
+
+## Code Conventions
+
+- **File operations:** Use `pathlib.Path`, never `os.path`.
+- **Logger:** Import via `from ..core.logging_config import get_logger`.
+- **LLM factory:** Use `from ..llm import create_chat_model` (centralized, never instantiate providers directly).
+- **Models:** All data models are Pydantic v2.
+- **Type hints:** `py.typed` is present; mypy strict mode is enforced.
+- **Line length:** 100 characters for both Black and Ruff.
+
+## Key Entry Points
+
+- **CLI script:** `poetry run truth-eval README.md` (or `poetry run python -m truthfulness_evaluator.truth`)
+- **Graph constructors:** `create_truthfulness_graph()` and `create_internal_verification_graph()` in `src/truthfulness_evaluator/llm/workflows/`
+- **Main module exports:** `src/truthfulness_evaluator/__init__.py` exposes all public APIs.
+
+## Operational Notes
+
+- **Generated files to ignore:** `site/` (MkDocs build), `llm_memory/` (LLM working memory), `CLAUDE.md` (local agent scratch), `*.html` (generated reports).
+- **No JSON manifest:** `pyproject.toml` is the single source of truth for deps and scripts.
+- **Docs theme:** MkDocs Material, with Python docstring handlers via `mkdocstrings`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,17 +61,17 @@ poetry run mypy src/
 ## Branch Workflow
 
 1. **Fork** the repository
-2. **Create a feature branch** from `dev` (not `main`):
+2. **Create a feature branch** from `develop` (not `main`):
    ```bash
-   git checkout dev
-   git pull origin dev
+   git checkout develop
+   git pull origin develop
    git checkout -b feature/your-feature-name
    ```
 3. **Make your changes** with clear, focused commits
-4. **Submit a Pull Request** targeting the `dev` branch
+4. **Submit a Pull Request** targeting the `develop` branch
 5. **Keep PRs focused** — one feature or fix per PR
 
-The `main` branch contains stable releases. Active development happens on `dev`.
+The `main` branch contains stable releases. Active development happens on `develop`.
 
 ## Commit Messages
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ cd truthfulness-evaluator
 poetry install
 ```
 
-Branch workflow: `main` is stable releases, `dev` is active development. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full workflow.
+Branch workflow: `main` is stable releases, `develop` is active development. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full workflow.
 
 ```bash
 poetry run pytest                              # Run tests


### PR DESCRIPTION
Standardizes all branch references from 'dev' to 'develop' across CONTRIBUTING.md, README.md, and AGENTS.md.\n\nAdds the new AGENTS.md with repo-specific guidance for AI agents, including the correct merge workflow.\n\n- CONTRIBUTING.md: dev→develop (checkout commands, PR target, branch description)\n- README.md: dev→develop in branch workflow description\n- AGENTS.md: new file with high-signal agent instructions, merge workflow, and toolchain config