### PR TITLE
docs: clarify workflow - no release branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,8 @@ Truthfulness Evaluator — Python CLI and library for multi-model claim verifica
 - **CI triggers:** pushes and PRs to `main` and `develop`.
 - **CI job order:** lint (Ruff) → format check (Black) → tests (pytest excluding e2e).
 - **Branch model:** `main` = stable releases; `develop` = active development. Feature branches branch from `develop` and PRs target `develop`. Releases are merged from `develop` → `main` via PR.
-- **Merging workflow:** New work → feature branch → PR to `develop` → PR `develop` → `main` for release.
+- **Merging workflow:** New work → feature branch → PR to `develop` → PR `develop` → `main` for release → tag `vX.Y.Z` → fast-forward `develop` to `main` so both branches align.
+- **No release branches:** Releases are cut by PRing `develop` directly to `main`. Do not create `release/*` branches.
 - **Conventional commits:** `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`.
 - **AI code review:** All PRs trigger `Sosoka-Labs/.github/.github/workflows/ai-code-review.yml@main` via `OPENAI_API_KEY` secret.
 - **Docs deploy:** `mkdocs build --strict` → GitHub Pages on every push to `main` that touches `docs/**`, `mkdocs.yml`, or `src/**`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,16 @@ poetry run mypy src/
 
 The `main` branch contains stable releases. Active development happens on `develop`.
 
+## Releases
+
+When `develop` is ready for release, a maintainer will:
+1. Update `CHANGELOG.md` with the release date
+2. PR `develop` → `main`
+3. Tag `vX.Y.Z` on the merge commit
+4. Fast-forward `develop` to `main` so both branches align
+
+No release branches are used.
+
 ## Commit Messages
 
 Follow conventional commit format for clarity and automated changelog generation:


### PR DESCRIPTION
Clarifies the release workflow to prevent the confusion that led to redundant release branches and divergent develop/main states.

**Changes:**
- `AGENTS.md` — added explicit note: "No release branches are used. Releases are cut by PRing develop directly to main."
- `AGENTS.md` — updated merging workflow to include: tag → fast-forward develop to main
- `CONTRIBUTING.md` — added new "Releases" section with the 4-step process (update changelog, PR to main, tag, fast-forward develop)
- `CONTRIBUTING.md` — explicitly states: "No release branches are used."

**Why this matters:**
Previously we accidentally created `release/v0.1.0` and `release/v0.1.0-to-main` branches, which was unnecessary. The simplified workflow is: feature → develop → main (PR) → tag → fast-forward develop.

**Verification:**
- `poetry run black` — passed
- `poetry run ruff check` — passed
- `poetry run pytest -m "not e2e"` — 199 passed, 0 failed
