### PR TITLE
refactor: cleanup imports, create llm/models package, eliminate inline imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced all relative `..` and `...` imports with absolute `truthfulness_evaluator.*` imports throughout the codebase
+- Moved inline/dynamic imports inside functions to top-of-file imports (except optional `refchecker` dependency)
+- Extracted Pydantic models from `llm/chains/` into a new `llm/models/` package for better separation of concerns
+
 ## [0.1.0] - 2026-06-05
 
 ### Added

--- a/src/truthfulness_evaluator/__init__.py
+++ b/src/truthfulness_evaluator/__init__.py
@@ -9,27 +9,44 @@ except PackageNotFoundError:
 
 # Legacy graph constructor
 # Protocols
-from .core.protocols import ClaimExtractor, ClaimVerifier, EvidenceGatherer, ReportFormatter
+from truthfulness_evaluator.core.protocols import (
+    ClaimExtractor,
+    ClaimVerifier,
+    EvidenceGatherer,
+    ReportFormatter,
+)
 
 # Workflow infrastructure
-from .llm.workflows import WorkflowConfig, WorkflowRegistry
-from .llm.workflows.graph import create_truthfulness_graph
-from .llm.workflows.presets import register_builtin_presets
+from truthfulness_evaluator.llm.workflows import WorkflowConfig, WorkflowRegistry
+from truthfulness_evaluator.llm.workflows.graph import create_truthfulness_graph
+from truthfulness_evaluator.llm.workflows.presets import register_builtin_presets
 
 # Domain models
-from .models import Claim, TruthfulnessReport, VerificationResult
+from truthfulness_evaluator.models import Claim, TruthfulnessReport, VerificationResult
 
 # Strategy adapters - Extractors
-from .strategies.extractors import SimpleExtractor, TripletExtractor
+from truthfulness_evaluator.strategies.extractors import SimpleExtractor, TripletExtractor
 
 # Strategy adapters - Formatters
-from .strategies.formatters import HtmlFormatter, JsonFormatter, MarkdownFormatter
+from truthfulness_evaluator.strategies.formatters import (
+    HtmlFormatter,
+    JsonFormatter,
+    MarkdownFormatter,
+)
 
 # Strategy adapters - Gatherers
-from .strategies.gatherers import CompositeGatherer, FilesystemGatherer, WebSearchGatherer
+from truthfulness_evaluator.strategies.gatherers import (
+    CompositeGatherer,
+    FilesystemGatherer,
+    WebSearchGatherer,
+)
 
 # Strategy adapters - Verifiers
-from .strategies.verifiers import ConsensusVerifier, InternalVerifier, SingleModelVerifier
+from truthfulness_evaluator.strategies.verifiers import (
+    ConsensusVerifier,
+    InternalVerifier,
+    SingleModelVerifier,
+)
 
 __all__ = [
     "__version__",

--- a/src/truthfulness_evaluator/core/grading.py
+++ b/src/truthfulness_evaluator/core/grading.py
@@ -1,6 +1,11 @@
 """Grading and summary logic for truthfulness reports."""
 
-from ..models import Claim, TruthfulnessReport, TruthfulnessStatistics, VerificationResult
+from truthfulness_evaluator.models import (
+    Claim,
+    TruthfulnessReport,
+    TruthfulnessStatistics,
+    VerificationResult,
+)
 
 
 def is_verified(

--- a/src/truthfulness_evaluator/core/protocols.py
+++ b/src/truthfulness_evaluator/core/protocols.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Protocol, runtime_checkable
 
-from ..models import Claim, Evidence, TruthfulnessReport, VerificationResult
+from truthfulness_evaluator.models import Claim, Evidence, TruthfulnessReport, VerificationResult
 
 __all__ = [
     "ClaimExtractor",

--- a/src/truthfulness_evaluator/evidence/agent.py
+++ b/src/truthfulness_evaluator/evidence/agent.py
@@ -6,9 +6,9 @@ from typing import Any
 
 from langgraph.prebuilt import create_react_agent
 
-from ..core.logging_config import get_logger
-from ..llm import create_chat_model
-from .tools.filesystem import get_filesystem_tools
+from truthfulness_evaluator.core.logging_config import get_logger
+from truthfulness_evaluator.evidence.tools.filesystem import get_filesystem_tools
+from truthfulness_evaluator.llm import create_chat_model
 
 logger = get_logger()
 

--- a/src/truthfulness_evaluator/evidence/tools/filesystem.py
+++ b/src/truthfulness_evaluator/evidence/tools/filesystem.py
@@ -1,5 +1,6 @@
 """Filesystem tools for evidence gathering."""
 
+import re
 from pathlib import Path
 
 from langchain_core.tools import tool
@@ -154,8 +155,6 @@ def get_filesystem_tools(root_path: str):
             related = []
 
             # Look for common reference patterns
-            import re
-
             # Python imports
             python_imports = re.findall(r"(?:from|import)\s+(\S+)", content)
             for imp in python_imports[:10]:

--- a/src/truthfulness_evaluator/evidence/tools/web_search.py
+++ b/src/truthfulness_evaluator/evidence/tools/web_search.py
@@ -2,6 +2,9 @@
 
 import re
 
+import requests
+from bs4 import BeautifulSoup
+from langchain_community.tools import DuckDuckGoSearchRun
 from langchain_core.tools import tool
 
 
@@ -21,8 +24,6 @@ def get_web_search_tools():
         """
         try:
             # Try DuckDuckGo first (no API key needed)
-            from langchain_community.tools import DuckDuckGoSearchRun
-
             search = DuckDuckGoSearchRun()
             results = search.run(query)
 
@@ -42,9 +43,6 @@ def get_web_search_tools():
             Extracted text content
         """
         try:
-            import requests
-            from bs4 import BeautifulSoup
-
             headers = {"User-Agent": "Mozilla/5.0 (compatible; TruthfulnessEvaluator/0.1)"}
 
             response = requests.get(url, headers=headers, timeout=10)

--- a/src/truthfulness_evaluator/llm/chains/consensus.py
+++ b/src/truthfulness_evaluator/llm/chains/consensus.py
@@ -3,9 +3,9 @@
 import asyncio
 from collections import Counter
 
-from ...core.logging_config import get_logger
-from ...models import Claim, Evidence, Verdict, VerificationResult
-from .verification import VerificationChain
+from truthfulness_evaluator.core.logging_config import get_logger
+from truthfulness_evaluator.llm.chains.verification import VerificationChain
+from truthfulness_evaluator.models import Claim, Evidence, Verdict, VerificationResult
 
 logger = get_logger()
 

--- a/src/truthfulness_evaluator/llm/chains/evidence.py
+++ b/src/truthfulness_evaluator/llm/chains/evidence.py
@@ -1,34 +1,9 @@
 """Evidence processing using structured outputs."""
 
-from typing import List, Optional
-
-from pydantic import BaseModel, Field
-
-from ...models import Claim, Evidence
-from ..factory import create_chat_model
-from ..prompts.verification import EVIDENCE_ANALYSIS_PROMPT
-
-
-# Structured output models
-class EvidenceAnalysisItem(BaseModel):
-    """Analysis of a single evidence item."""
-
-    index: int = Field(description="Index of the evidence item")
-    relevance: float = Field(description="Relevance score from 0.0 to 1.0")
-    supports: Optional[bool] = Field(
-        None, description="True if supports, False if refutes, null if neutral"
-    )
-    credibility: float = Field(description="Credibility score from 0.0 to 1.0")
-    reasoning: str = Field(description="Brief reasoning for the assessment")
-
-
-class EvidenceAnalysisOutput(BaseModel):
-    """Structured output for evidence analysis."""
-
-    evidence_analysis: List[EvidenceAnalysisItem] = Field(
-        description="Analysis of each evidence item"
-    )
-    summary: str = Field(description="Overall summary of evidence quality")
+from truthfulness_evaluator.llm.factory import create_chat_model
+from truthfulness_evaluator.llm.models import EvidenceAnalysisOutput
+from truthfulness_evaluator.llm.prompts.verification import EVIDENCE_ANALYSIS_PROMPT
+from truthfulness_evaluator.models import Claim, Evidence
 
 
 class EvidenceProcessor:

--- a/src/truthfulness_evaluator/llm/chains/extraction.py
+++ b/src/truthfulness_evaluator/llm/chains/extraction.py
@@ -2,9 +2,7 @@
 
 import asyncio
 import re
-from typing import List, Optional
-
-from pydantic import BaseModel, Field
+from typing import Optional
 
 try:
     from refchecker.extractor import LLMExtractor
@@ -13,10 +11,17 @@ try:
 except ImportError:
     REFCHECKER_AVAILABLE = False
 
-from ...core.logging_config import get_logger
-from ...models import Claim
-from ..factory import create_chat_model
-from ..prompts.extraction import CLAIM_EXTRACTION_PROMPT, TRIPLET_EXTRACTION_PROMPT
+from truthfulness_evaluator.core.logging_config import get_logger
+from truthfulness_evaluator.llm.factory import create_chat_model
+from truthfulness_evaluator.llm.models import (
+    ClaimExtractionOutput,
+    TripletExtractionOutput,
+)
+from truthfulness_evaluator.llm.prompts.extraction import (
+    CLAIM_EXTRACTION_PROMPT,
+    TRIPLET_EXTRACTION_PROMPT,
+)
+from truthfulness_evaluator.models import Claim
 
 logger = get_logger()
 
@@ -48,35 +53,6 @@ def strip_example_blocks(text: str) -> str:
     # Inline code spans
     text = re.sub(r"`[^`]+`", "", text)
     return text
-
-
-# Structured output models
-class ExtractedClaim(BaseModel):
-    """A single extracted claim."""
-
-    text: str = Field(description="The claim text")
-    claim_type: str = Field(description="Type: explicit, implicit, or inferred")
-
-
-class ClaimExtractionOutput(BaseModel):
-    """Output structure for claim extraction."""
-
-    claims: List[ExtractedClaim] = Field(description="List of extracted claims")
-
-
-class KnowledgeTriplet(BaseModel):
-    """Subject-relation-object triplet."""
-
-    subject: str = Field(description="The subject of the claim")
-    relation: str = Field(description="The relationship/action")
-    object: str = Field(description="The object/target")
-    context: Optional[str] = Field(None, description="Additional context")
-
-
-class TripletExtractionOutput(BaseModel):
-    """Output structure for triplet extraction."""
-
-    triplets: List[KnowledgeTriplet] = Field(description="List of knowledge triplets")
 
 
 class ClaimExtractionChain:

--- a/src/truthfulness_evaluator/llm/chains/internal_verification.py
+++ b/src/truthfulness_evaluator/llm/chains/internal_verification.py
@@ -6,34 +6,13 @@ from pathlib import Path
 from typing import Optional
 
 from langchain_core.prompts import ChatPromptTemplate
-from pydantic import BaseModel, Field
 
-from ...core.logging_config import get_logger
-from ...models import Claim, Evidence, VerificationResult
-from ..factory import create_chat_model
+from truthfulness_evaluator.core.logging_config import get_logger
+from truthfulness_evaluator.llm.factory import create_chat_model
+from truthfulness_evaluator.llm.models import ClaimClassification, InternalVerificationOutput
+from truthfulness_evaluator.models import Claim, Evidence, VerificationResult
 
 logger = get_logger()
-
-
-# Structured output models
-class ClaimClassification(BaseModel):
-    """Classification of claim type."""
-
-    claim_type: str = Field(
-        description="Type: external_fact, api_signature, version_requirement, configuration, behavioral, or unknown"
-    )
-    confidence: float = Field(description="Confidence in classification (0.0-1.0)")
-    reasoning: str = Field(description="Why this classification")
-
-
-class InternalVerificationOutput(BaseModel):
-    """Output for internal verification."""
-
-    verdict: str = Field(description="SUPPORTS, REFUTES, or NOT_ENOUGH_INFO")
-    confidence: float = Field(description="Confidence 0.0-1.0")
-    reasoning: str = Field(description="Detailed explanation")
-    actual_implementation: Optional[str] = Field(None, description="What was actually found")
-    discrepancy: Optional[str] = Field(None, description="Specific discrepancy if any")
 
 
 class ClaimClassifier:

--- a/src/truthfulness_evaluator/llm/chains/verification.py
+++ b/src/truthfulness_evaluator/llm/chains/verification.py
@@ -1,22 +1,9 @@
 """Verification chains using structured outputs."""
 
-from typing import Optional
-
-from pydantic import BaseModel, Field
-
-from ...models import Claim, Evidence, VerificationResult
-from ..factory import create_chat_model
-from ..prompts.verification import VERIFICATION_PROMPT
-
-
-# Structured output models
-class VerificationOutput(BaseModel):
-    """Structured output for claim verification."""
-
-    verdict: str = Field(description="Verdict: SUPPORTS, REFUTES, or NOT_ENOUGH_INFO")
-    confidence: float = Field(description="Confidence score from 0.0 to 1.0")
-    reasoning: str = Field(description="Detailed explanation of the verdict")
-    key_evidence: Optional[str] = Field(None, description="Most important evidence considered")
+from truthfulness_evaluator.llm.factory import create_chat_model
+from truthfulness_evaluator.llm.models import VerificationOutput
+from truthfulness_evaluator.llm.prompts.verification import VERIFICATION_PROMPT
+from truthfulness_evaluator.models import Claim, Evidence, VerificationResult
 
 
 class VerificationChain:

--- a/src/truthfulness_evaluator/llm/factory.py
+++ b/src/truthfulness_evaluator/llm/factory.py
@@ -2,9 +2,12 @@
 
 from typing import Any
 
+import langchain_anthropic
+import langchain_fireworks
+import langchain_openai
 from langchain_core.language_models import BaseChatModel
 
-from ..core.logging_config import get_logger
+from truthfulness_evaluator.core.logging_config import get_logger
 
 logger = get_logger()
 
@@ -69,15 +72,13 @@ def create_chat_model(
     logger.debug("Creating %s model: %s", provider, model_name)
 
     if provider == "anthropic":
-        from langchain_anthropic import ChatAnthropic
-
-        return ChatAnthropic(model=model_name, temperature=temperature, **kwargs)
+        return langchain_anthropic.ChatAnthropic(
+            model=model_name, temperature=temperature, **kwargs
+        )
 
     if provider == "fireworks":
-        from langchain_fireworks import ChatFireworks
+        return langchain_fireworks.ChatFireworks(
+            model=model_name, temperature=temperature, **kwargs
+        )
 
-        return ChatFireworks(model=model_name, temperature=temperature, **kwargs)
-
-    from langchain_openai import ChatOpenAI
-
-    return ChatOpenAI(model=model_name, temperature=temperature, **kwargs)
+    return langchain_openai.ChatOpenAI(model=model_name, temperature=temperature, **kwargs)

--- a/src/truthfulness_evaluator/llm/models/__init__.py
+++ b/src/truthfulness_evaluator/llm/models/__init__.py
@@ -1,0 +1,21 @@
+from .evidence import EvidenceAnalysisItem, EvidenceAnalysisOutput
+from .extraction import (
+    ClaimExtractionOutput,
+    ExtractedClaim,
+    KnowledgeTriplet,
+    TripletExtractionOutput,
+)
+from .internal_verification import ClaimClassification, InternalVerificationOutput
+from .verification import VerificationOutput
+
+__all__ = [
+    "ExtractedClaim",
+    "ClaimExtractionOutput",
+    "KnowledgeTriplet",
+    "TripletExtractionOutput",
+    "VerificationOutput",
+    "EvidenceAnalysisItem",
+    "EvidenceAnalysisOutput",
+    "ClaimClassification",
+    "InternalVerificationOutput",
+]

--- a/src/truthfulness_evaluator/llm/models/evidence.py
+++ b/src/truthfulness_evaluator/llm/models/evidence.py
@@ -1,0 +1,26 @@
+"""Pydantic models for evidence analysis."""
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class EvidenceAnalysisItem(BaseModel):
+    """Analysis of a single evidence item."""
+
+    index: int = Field(description="Index of the evidence item")
+    relevance: float = Field(description="Relevance score from 0.0 to 1.0")
+    supports: Optional[bool] = Field(
+        None, description="True if supports, False if refutes, null if neutral"
+    )
+    credibility: float = Field(description="Credibility score from 0.0 to 1.0")
+    reasoning: str = Field(description="Brief reasoning for the assessment")
+
+
+class EvidenceAnalysisOutput(BaseModel):
+    """Structured output for evidence analysis."""
+
+    evidence_analysis: List[EvidenceAnalysisItem] = Field(
+        description="Analysis of each evidence item"
+    )
+    summary: str = Field(description="Overall summary of evidence quality")

--- a/src/truthfulness_evaluator/llm/models/extraction.py
+++ b/src/truthfulness_evaluator/llm/models/extraction.py
@@ -1,0 +1,33 @@
+"""Pydantic models for claim extraction."""
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ExtractedClaim(BaseModel):
+    """A single extracted claim."""
+
+    text: str = Field(description="The claim text")
+    claim_type: str = Field(description="Type: explicit, implicit, or inferred")
+
+
+class ClaimExtractionOutput(BaseModel):
+    """Output structure for claim extraction."""
+
+    claims: List[ExtractedClaim] = Field(description="List of extracted claims")
+
+
+class KnowledgeTriplet(BaseModel):
+    """Subject-relation-object triplet."""
+
+    subject: str = Field(description="The subject of the claim")
+    relation: str = Field(description="The relationship/action")
+    object: str = Field(description="The object/target")
+    context: Optional[str] = Field(None, description="Additional context")
+
+
+class TripletExtractionOutput(BaseModel):
+    """Output structure for triplet extraction."""
+
+    triplets: List[KnowledgeTriplet] = Field(description="List of knowledge triplets")

--- a/src/truthfulness_evaluator/llm/models/internal_verification.py
+++ b/src/truthfulness_evaluator/llm/models/internal_verification.py
@@ -1,0 +1,25 @@
+"""Pydantic models for internal verification."""
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class ClaimClassification(BaseModel):
+    """Classification of claim type."""
+
+    claim_type: str = Field(
+        description="Type: external_fact, api_signature, version_requirement, configuration, behavioral, or unknown"
+    )
+    confidence: float = Field(description="Confidence in classification (0.0-1.0)")
+    reasoning: str = Field(description="Why this classification")
+
+
+class InternalVerificationOutput(BaseModel):
+    """Output for internal verification."""
+
+    verdict: str = Field(description="SUPPORTS, REFUTES, or NOT_ENOUGH_INFO")
+    confidence: float = Field(description="Confidence 0.0-1.0")
+    reasoning: str = Field(description="Detailed explanation")
+    actual_implementation: Optional[str] = Field(None, description="What was actually found")
+    discrepancy: Optional[str] = Field(None, description="Specific discrepancy if any")

--- a/src/truthfulness_evaluator/llm/models/verification.py
+++ b/src/truthfulness_evaluator/llm/models/verification.py
@@ -1,0 +1,14 @@
+"""Pydantic models for verification."""
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class VerificationOutput(BaseModel):
+    """Structured output for claim verification."""
+
+    verdict: str = Field(description="Verdict: SUPPORTS, REFUTES, or NOT_ENOUGH_INFO")
+    confidence: float = Field(description="Confidence score from 0.0 to 1.0")
+    reasoning: str = Field(description="Detailed explanation of the verdict")
+    key_evidence: Optional[str] = Field(None, description="Most important evidence considered")

--- a/src/truthfulness_evaluator/llm/workflows/builder.py
+++ b/src/truthfulness_evaluator/llm/workflows/builder.py
@@ -1,6 +1,6 @@
 """Workflow builder for constructing LangGraph state machines."""
 
-from .config import WorkflowConfig
+from truthfulness_evaluator.llm.workflows.config import WorkflowConfig
 
 
 class WorkflowBuilder:

--- a/src/truthfulness_evaluator/llm/workflows/config.py
+++ b/src/truthfulness_evaluator/llm/workflows/config.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from ...core.protocols import ClaimExtractor, ClaimVerifier, EvidenceGatherer, ReportFormatter
+from truthfulness_evaluator.core.protocols import (
+    ClaimExtractor,
+    ClaimVerifier,
+    EvidenceGatherer,
+    ReportFormatter,
+)
 
 
 @dataclass

--- a/src/truthfulness_evaluator/llm/workflows/graph.py
+++ b/src/truthfulness_evaluator/llm/workflows/graph.py
@@ -5,9 +5,15 @@ from langgraph.graph import END, START, StateGraph
 from langgraph.types import interrupt
 from typing_extensions import TypedDict
 
-from ...core.config import EvaluatorConfig
-from ...core.logging_config import get_logger
-from ...models import Claim, Evidence, TruthfulnessReport, VerificationResult
+from truthfulness_evaluator.core.config import EvaluatorConfig
+from truthfulness_evaluator.core.grading import build_report
+from truthfulness_evaluator.core.logging_config import get_logger
+from truthfulness_evaluator.evidence.agent import FilesystemEvidenceAgent
+from truthfulness_evaluator.evidence.tools.web_search import WebEvidenceGatherer
+from truthfulness_evaluator.llm.chains.consensus import ConsensusChain
+from truthfulness_evaluator.llm.chains.evidence import EvidenceProcessor
+from truthfulness_evaluator.llm.chains.extraction import SimpleClaimExtractionChain
+from truthfulness_evaluator.models import Claim, Evidence, TruthfulnessReport, VerificationResult
 
 logger = get_logger()
 
@@ -34,8 +40,6 @@ def get_config_from_state(state: TruthfulnessState) -> EvaluatorConfig:
 # Node implementations
 async def extract_claims_node(state: TruthfulnessState) -> dict:
     """Extract claims from document."""
-    from ..chains.extraction import SimpleClaimExtractionChain
-
     config = get_config_from_state(state)
 
     # Use simple extraction for now (RefChecker has dependency issues)
@@ -67,8 +71,6 @@ async def search_evidence_node(state: TruthfulnessState) -> dict:
 
     # Filesystem search
     if config.enable_filesystem_search and state["root_path"]:
-        from ...evidence.agent import FilesystemEvidenceAgent
-
         try:
             agent = FilesystemEvidenceAgent(state["root_path"])
             fs_evidence = await agent.search(claim.text)
@@ -91,8 +93,6 @@ async def search_evidence_node(state: TruthfulnessState) -> dict:
 
     # Web search
     if config.enable_web_search:
-        from ...evidence.tools.web_search import WebEvidenceGatherer
-
         try:
             gatherer = WebEvidenceGatherer()
             web_evidence = await gatherer.gather_evidence(claim.text, max_results=3)
@@ -120,8 +120,6 @@ async def search_evidence_node(state: TruthfulnessState) -> dict:
 
     # Process and analyze evidence
     if evidence:
-        from ..chains.evidence import EvidenceProcessor
-
         processor = EvidenceProcessor(model=config.claim_extraction_model)
 
         try:
@@ -157,8 +155,6 @@ async def verify_claim_node(state: TruthfulnessState) -> dict:
     evidence = state.get("evidence_cache", {}).get(claim.id, [])
 
     logger.info(f"Verifying: {claim.text[:60]}...")
-
-    from ..chains.consensus import ConsensusChain
 
     consensus = ConsensusChain(
         model_names=config.verification_models, confidence_threshold=config.confidence_threshold
@@ -214,8 +210,6 @@ def should_continue(state: TruthfulnessState) -> str:
 
 async def generate_report_node(state: TruthfulnessState) -> dict:
     """Generate final truthfulness report."""
-    from ...core.grading import build_report
-
     verifications = state["verifications"]
     claims = state["claims"]
 

--- a/src/truthfulness_evaluator/llm/workflows/graph_internal.py
+++ b/src/truthfulness_evaluator/llm/workflows/graph_internal.py
@@ -6,9 +6,17 @@ from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, START, StateGraph
 from typing_extensions import TypedDict
 
-from ...core.config import EvaluatorConfig
-from ...core.logging_config import get_logger
-from ...models import Claim, Evidence, TruthfulnessReport, VerificationResult
+from truthfulness_evaluator.core.config import EvaluatorConfig
+from truthfulness_evaluator.core.grading import build_report
+from truthfulness_evaluator.core.logging_config import get_logger
+from truthfulness_evaluator.evidence.tools.web_search import WebEvidenceGatherer
+from truthfulness_evaluator.llm.chains.consensus import ConsensusChain
+from truthfulness_evaluator.llm.chains.extraction import SimpleClaimExtractionChain
+from truthfulness_evaluator.llm.chains.internal_verification import (
+    ClaimClassifier,
+    InternalVerificationChain,
+)
+from truthfulness_evaluator.models import Claim, Evidence, TruthfulnessReport, VerificationResult
 
 logger = get_logger()
 
@@ -36,9 +44,6 @@ def get_config_from_state(state: InternalVerificationState) -> EvaluatorConfig:
 
 async def extract_and_classify_claims_node(state: InternalVerificationState) -> dict:
     """Extract claims and classify as external vs internal."""
-    from ..chains.extraction import SimpleClaimExtractionChain
-    from ..chains.internal_verification import ClaimClassifier
-
     config = get_config_from_state(state)
 
     # Extract claims
@@ -119,13 +124,9 @@ async def _verify_external(
     claim: Claim, state: InternalVerificationState, config: EvaluatorConfig
 ) -> VerificationResult:
     """Verify using external sources (web search)."""
-    from ..chains.consensus import ConsensusChain
-
     # Gather web evidence
     evidence = []
     if config.enable_web_search:
-        from ...evidence.tools.web_search import WebEvidenceGatherer
-
         try:
             gatherer = WebEvidenceGatherer()
             web_evidence = await gatherer.gather_evidence(claim.text, max_results=2)
@@ -154,8 +155,6 @@ async def _verify_internal(
     claim: Claim, state: InternalVerificationState, config: EvaluatorConfig
 ) -> VerificationResult:
     """Verify using internal codebase."""
-    from ..chains.internal_verification import ClaimClassifier, InternalVerificationChain
-
     if not state["root_path"]:
         return VerificationResult(
             claim_id=claim.id,
@@ -189,8 +188,6 @@ def should_continue(state: InternalVerificationState) -> str:
 
 async def generate_report_node(state: InternalVerificationState) -> dict:
     """Generate final truthfulness report."""
-    from ...core.grading import build_report
-
     verifications = state["verifications"]
     claims = state["claims"]
 

--- a/src/truthfulness_evaluator/llm/workflows/presets.py
+++ b/src/truthfulness_evaluator/llm/workflows/presets.py
@@ -1,11 +1,23 @@
 """Built-in workflow presets."""
 
-from ...strategies.extractors import SimpleExtractor
-from ...strategies.formatters import HtmlFormatter, JsonFormatter, MarkdownFormatter
-from ...strategies.gatherers import CompositeGatherer, FilesystemGatherer, WebSearchGatherer
-from ...strategies.verifiers import ConsensusVerifier, InternalVerifier, SingleModelVerifier
-from .config import WorkflowConfig
-from .registry import WorkflowRegistry
+from truthfulness_evaluator.llm.workflows.config import WorkflowConfig
+from truthfulness_evaluator.llm.workflows.registry import WorkflowRegistry
+from truthfulness_evaluator.strategies.extractors import SimpleExtractor
+from truthfulness_evaluator.strategies.formatters import (
+    HtmlFormatter,
+    JsonFormatter,
+    MarkdownFormatter,
+)
+from truthfulness_evaluator.strategies.gatherers import (
+    CompositeGatherer,
+    FilesystemGatherer,
+    WebSearchGatherer,
+)
+from truthfulness_evaluator.strategies.verifiers import (
+    ConsensusVerifier,
+    InternalVerifier,
+    SingleModelVerifier,
+)
 
 
 def register_builtin_presets() -> None:

--- a/src/truthfulness_evaluator/llm/workflows/registry.py
+++ b/src/truthfulness_evaluator/llm/workflows/registry.py
@@ -1,7 +1,9 @@
 """Workflow registry with built-in presets and plugin support."""
 
-from ...core.logging_config import get_logger
-from .config import WorkflowConfig
+from importlib.metadata import entry_points
+
+from truthfulness_evaluator.core.logging_config import get_logger
+from truthfulness_evaluator.llm.workflows.config import WorkflowConfig
 
 logger = get_logger()
 
@@ -83,8 +85,6 @@ class WorkflowRegistry:
         cls._discovered = True
 
         try:
-            from importlib.metadata import entry_points
-
             eps = entry_points(group="truthfulness_evaluator.workflows")
             for ep in eps:
                 try:

--- a/src/truthfulness_evaluator/llm/workflows/state.py
+++ b/src/truthfulness_evaluator/llm/workflows/state.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from typing_extensions import TypedDict
 
-from ...models import Claim, Evidence, TruthfulnessReport, VerificationResult
+from truthfulness_evaluator.models import Claim, Evidence, TruthfulnessReport, VerificationResult
 
 
 class WorkflowState(TypedDict):

--- a/src/truthfulness_evaluator/reporting/generator.py
+++ b/src/truthfulness_evaluator/reporting/generator.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from jinja2 import Environment, PackageLoader, select_autoescape
 
-from ..models import TruthfulnessReport
+from truthfulness_evaluator.models import TruthfulnessReport
 
 
 def _format_percent(value: float) -> str:

--- a/src/truthfulness_evaluator/strategies/extractors/simple.py
+++ b/src/truthfulness_evaluator/strategies/extractors/simple.py
@@ -1,7 +1,7 @@
 """Simple claim extraction adapter."""
 
-from ...llm.chains.extraction import SimpleClaimExtractionChain
-from ...models import Claim
+from truthfulness_evaluator.llm.chains.extraction import SimpleClaimExtractionChain
+from truthfulness_evaluator.models import Claim
 
 
 class SimpleExtractor:

--- a/src/truthfulness_evaluator/strategies/extractors/triplet.py
+++ b/src/truthfulness_evaluator/strategies/extractors/triplet.py
@@ -1,7 +1,7 @@
 """Triplet-based claim extraction adapter."""
 
-from ...llm.chains.extraction import TripletExtractionChain
-from ...models import Claim
+from truthfulness_evaluator.llm.chains.extraction import TripletExtractionChain
+from truthfulness_evaluator.models import Claim
 
 
 class TripletExtractor:

--- a/src/truthfulness_evaluator/strategies/formatters/html.py
+++ b/src/truthfulness_evaluator/strategies/formatters/html.py
@@ -1,6 +1,7 @@
 """HTML report formatter."""
 
-from ...models import TruthfulnessReport
+from truthfulness_evaluator.models import TruthfulnessReport
+from truthfulness_evaluator.reporting.generator import ReportGenerator
 
 
 class HtmlFormatter:
@@ -8,8 +9,6 @@ class HtmlFormatter:
 
     def format(self, report: TruthfulnessReport) -> str:
         """Format a truthfulness report as HTML."""
-        from ...reporting.generator import ReportGenerator
-
         gen = ReportGenerator(report)
         return gen.to_html()
 

--- a/src/truthfulness_evaluator/strategies/formatters/json_fmt.py
+++ b/src/truthfulness_evaluator/strategies/formatters/json_fmt.py
@@ -1,6 +1,6 @@
 """JSON report formatter."""
 
-from ...models import TruthfulnessReport
+from truthfulness_evaluator.models import TruthfulnessReport
 
 
 class JsonFormatter:

--- a/src/truthfulness_evaluator/strategies/formatters/markdown.py
+++ b/src/truthfulness_evaluator/strategies/formatters/markdown.py
@@ -1,6 +1,7 @@
 """Markdown report formatter."""
 
-from ...models import TruthfulnessReport
+from truthfulness_evaluator.models import TruthfulnessReport
+from truthfulness_evaluator.reporting.generator import ReportGenerator
 
 
 class MarkdownFormatter:
@@ -8,8 +9,6 @@ class MarkdownFormatter:
 
     def format(self, report: TruthfulnessReport) -> str:
         """Format a truthfulness report as Markdown."""
-        from ...reporting.generator import ReportGenerator
-
         gen = ReportGenerator(report)
         return gen.to_markdown()
 

--- a/src/truthfulness_evaluator/strategies/gatherers/composite.py
+++ b/src/truthfulness_evaluator/strategies/gatherers/composite.py
@@ -3,9 +3,9 @@
 import asyncio
 from typing import Any
 
-from ...core.logging_config import get_logger
-from ...core.protocols import EvidenceGatherer
-from ...models import Claim, Evidence
+from truthfulness_evaluator.core.logging_config import get_logger
+from truthfulness_evaluator.core.protocols import EvidenceGatherer
+from truthfulness_evaluator.models import Claim, Evidence
 
 logger = get_logger()
 

--- a/src/truthfulness_evaluator/strategies/gatherers/filesystem.py
+++ b/src/truthfulness_evaluator/strategies/gatherers/filesystem.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-from ...core.logging_config import get_logger
-from ...evidence.agent import FilesystemEvidenceAgent
-from ...models import Claim, Evidence
+from truthfulness_evaluator.core.logging_config import get_logger
+from truthfulness_evaluator.evidence.agent import FilesystemEvidenceAgent
+from truthfulness_evaluator.models import Claim, Evidence
 
 logger = get_logger()
 

--- a/src/truthfulness_evaluator/strategies/gatherers/web.py
+++ b/src/truthfulness_evaluator/strategies/gatherers/web.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-from ...core.logging_config import get_logger
-from ...evidence.tools.web_search import WebEvidenceGatherer
-from ...models import Claim, Evidence
+from truthfulness_evaluator.core.logging_config import get_logger
+from truthfulness_evaluator.evidence.tools.web_search import WebEvidenceGatherer
+from truthfulness_evaluator.models import Claim, Evidence
 
 logger = get_logger()
 

--- a/src/truthfulness_evaluator/strategies/verifiers/consensus.py
+++ b/src/truthfulness_evaluator/strategies/verifiers/consensus.py
@@ -1,8 +1,8 @@
 """Multi-model consensus verification adapter."""
 
-from ...core.logging_config import get_logger
-from ...llm.chains.consensus import ConsensusChain
-from ...models import Claim, Evidence, VerificationResult
+from truthfulness_evaluator.core.logging_config import get_logger
+from truthfulness_evaluator.llm.chains.consensus import ConsensusChain
+from truthfulness_evaluator.models import Claim, Evidence, VerificationResult
 
 logger = get_logger()
 

--- a/src/truthfulness_evaluator/strategies/verifiers/internal.py
+++ b/src/truthfulness_evaluator/strategies/verifiers/internal.py
@@ -1,8 +1,11 @@
 """Internal/codebase verification adapter."""
 
-from ...core.logging_config import get_logger
-from ...llm.chains.internal_verification import ClaimClassifier, InternalVerificationChain
-from ...models import Claim, Evidence, VerificationResult
+from truthfulness_evaluator.core.logging_config import get_logger
+from truthfulness_evaluator.llm.chains.internal_verification import (
+    ClaimClassifier,
+    InternalVerificationChain,
+)
+from truthfulness_evaluator.models import Claim, Evidence, VerificationResult
 
 logger = get_logger()
 

--- a/src/truthfulness_evaluator/strategies/verifiers/single_model.py
+++ b/src/truthfulness_evaluator/strategies/verifiers/single_model.py
@@ -1,8 +1,8 @@
 """Single-model verification adapter."""
 
-from ...core.logging_config import get_logger
-from ...llm.chains.verification import VerificationChain
-from ...models import Claim, Evidence, VerificationResult
+from truthfulness_evaluator.core.logging_config import get_logger
+from truthfulness_evaluator.llm.chains.verification import VerificationChain
+from truthfulness_evaluator.models import Claim, Evidence, VerificationResult
 
 logger = get_logger()
 

--- a/src/truthfulness_evaluator/truth.py
+++ b/src/truthfulness_evaluator/truth.py
@@ -9,10 +9,11 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
-from .core.config import get_config
-from .llm.workflows.graph import create_truthfulness_graph
-from .llm.workflows.graph_internal import create_internal_verification_graph
-from .reporting import ReportGenerator
+from truthfulness_evaluator import __version__
+from truthfulness_evaluator.core.config import get_config
+from truthfulness_evaluator.llm.workflows.graph import create_truthfulness_graph
+from truthfulness_evaluator.llm.workflows.graph_internal import create_internal_verification_graph
+from truthfulness_evaluator.reporting import ReportGenerator
 
 app = typer.Typer(help="Truthfulness Evaluator - Verify claims in documents")
 console = Console()
@@ -205,8 +206,6 @@ def evaluate(
 @app.command()
 def version():
     """Show version information."""
-    from . import __version__
-
     console.print(f"Truthfulness Evaluator v{__version__}")
 
 


### PR DESCRIPTION
## Summary

Housekeeping cleanup pass focused on import hygiene and separation of concerns.

### Changes
- **Eliminated relative imports**: Replaced all `..` and `...` relative imports with absolute `truthfulness_evaluator.*` imports across the entire codebase.
- **Created `llm/models` package**: Extracted Pydantic BaseModel classes from chain logic files into a dedicated models package for better separation of concerns.
  - `llm/models/extraction.py`
  - `llm/models/verification.py`
  - `llm/models/evidence.py`
  - `llm/models/internal_verification.py`
- **Eliminated inline imports**: Moved all dynamic/inline imports inside functions to top-of-file imports (except the optional `refchecker` dependency). Key fixes:
  - `factory.py`: langchain providers imported at module level (attribute access preserves test mocking)
  - `graph.py` / `graph_internal.py`: all inline imports moved to top
  - `registry.py`, `formatters`, `evidence/tools`, `truth.py`: inline imports moved to top

### Verification
- 199 tests passed
- Ruff passes clean
- Black formatting verified

No logic or behavior changes — purely structural cleanup.

---

- Updated `CHANGELOG.md` [Unreleased] section.