### PR TITLE
fix: isolate config tests from ambient .env and environment

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,29 @@
 """Tests for truthfulness_evaluator.config module."""
 
+import os
+
+import pytest
 from truthfulness_evaluator.core.config import EvaluatorConfig, get_config
+
+# Env vars that would otherwise leak the developer's real configuration into
+# these tests. EvaluatorConfig reads the TRUTH_ prefix plus these bare keys.
+_LEAKY_ENV_VARS = ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "FIREWORKS_API_KEY")
+
+
+@pytest.fixture(autouse=True)
+def isolate_config_env(monkeypatch, tmp_path):
+    """Isolate config tests from the developer's ambient .env and env vars.
+
+    EvaluatorConfig loads a ``.env`` from the working directory and honours any
+    ``TRUTH_``-prefixed variables. Without isolation these tests pass or fail
+    depending on the machine they run on. Changing to an empty directory drops
+    the .env, and clearing the relevant variables gives every test a clean,
+    deterministic baseline; tests that need specific values set them explicitly.
+    """
+    monkeypatch.chdir(tmp_path)
+    for key in list(os.environ):
+        if key.startswith("TRUTH_") or key in _LEAKY_ENV_VARS:
+            monkeypatch.delenv(key, raising=False)
 
 
 class TestEvaluatorConfig:


### PR DESCRIPTION
## Problem
`test_config.py` constructs `EvaluatorConfig()` expecting defaults, but `EvaluatorConfig` loads a `.env` from the working directory and honours `TRUTH_`-prefixed variables. The tests therefore passed or failed depending on the developer's machine. A stray `TRUTH_` variable that doesn't map to a field makes pydantic-settings raise `extra_forbidden`, failing the whole module.

## Fix
Add an autouse fixture that runs each config test in an empty working directory with `TRUTH_` and API-key variables cleared, giving a deterministic baseline. Tests that need specific values continue to set them explicitly via `monkeypatch`.

Production behavior is unchanged — `extra="forbid"` stays (it's fail-fast and correctly surfaces config typos). This is purely a test-isolation fix.

## Result
`test_config.py`: 22 passed. Full suite on the develop base: green.